### PR TITLE
Fix for https://github.com/BJReplay/ha-solcast-solar/issues/14

### DIFF
--- a/custom_components/solcast_solar/__init__.py
+++ b/custom_components/solcast_solar/__init__.py
@@ -91,7 +91,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         entry.options[CONF_API_KEY],
         SOLCAST_URL,
         hass.config.path('solcast.json'),
-        dt_util.get_time_zone(hass.config.time_zone),
+        dt_util.async_get_time_zone(hass.config.time_zone),
         optdamp,
         entry.options[CUSTOM_HOUR_SENSOR],
         entry.options.get(KEY_ESTIMATE,"estimate"),


### PR DESCRIPTION
changed dt_util.get_time_zone to dt_util.async_get_time_zone. Credit to @ma9mwah