### PR TITLE
Three tries at rooftop sites, then fall-back to cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ You probably **do not** want to do this! Use the HACS method above unless you kn
 
 [<img src="https://github.com/BJReplay/ha-solcast-solar/blob/v3/.github/SCREENSHOTS/install.png" width="200">](https://github.com/BJReplay/ha-solcast-solar/blob/v3/.github/SCREENSHOTS/install.png)
 
+> [!IMPORTANT]
+> After the integration is started, review the Home Assistant log.
+> 
+> Should an error that gathering rooftop sites data has failed occur then this is not an integration issue, rather a Solcast API issue. The best course of action is to restart the integration, or Home Assistant entirely, and monitor until the sites data can be acquired. Until rooftop sites data is acquired the integration cannot function. 
+> The integration does attempt retries when the Solcast API is busy, but sometimes even this does not help.
+
 ## Dampening Configuration
 
 New in v4.0.8 is the option to configure hourly dampening values

--- a/custom_components/solcast_solar/__init__.py
+++ b/custom_components/solcast_solar/__init__.py
@@ -67,11 +67,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up solcast parameters."""
 
     #new in v4.0.16 for the selector of which field to use from the data
-    if entry.options.get(KEY_ESTIMATE,None) == None:
+    if entry.options.get(KEY_ESTIMATE,None) is None:
         new = {**entry.options}
         new[KEY_ESTIMATE] = "estimate"
-        entry.version = 7
-        hass.config_entries.async_update_entry(entry, options=new)
+        hass.config_entries.async_update_entry(entry, options=new, version=7)
 
 
     optdamp = {}
@@ -112,7 +111,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     try:
         await solcast.sites_data()
-        await solcast.sites_usage()
+        #await solcast.sites_usage()
     except Exception as ex:
         raise ConfigEntryNotReady(f"Getting sites data failed: {ex}") from ex
 
@@ -289,8 +288,16 @@ async def async_remove_config_entry_device(hass: HomeAssistant, entry: ConfigEnt
     return True
 
 async def async_update_options(hass: HomeAssistant, entry: ConfigEntry):
-    """Reload entry if options change."""
-    await hass.config_entries.async_reload(entry.entry_id)
+    """Handle options update. Only reload if any item was changed"""
+    if any(
+        entry.data.get(attrib) != entry.options.get(attrib)
+        for attrib in (DAMP_FACTOR, HARD_LIMIT,KEY_ESTIMATE, CUSTOM_HOUR_SENSOR, CONF_API_KEY)
+    ):
+        # update entry replacing data with new options
+        hass.config_entries.async_update_entry(
+            entry, data={**entry.data, **entry.options}
+        )
+        await hass.config_entries.async_reload(entry.entry_id)
 
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Migrate old entry."""
@@ -299,9 +306,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
     if config_entry.version < 4:
         new_options = {**config_entry.options}
         new_options.pop("const_disableautopoll", None)
-        config_entry.version = 4
-
-        hass.config_entries.async_update_entry(config_entry, options=new_options)
+        hass.config_entries.async_update_entry(config_entry, options=new_options, version=4)
 
     #new 4.0.8
     #power factor for each hour
@@ -309,27 +314,21 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         new = {**config_entry.options}
         for a in range(0,24):
             new[f"damp{str(a).zfill(2)}"] = 1.0
-        config_entry.version = 5
-
-        hass.config_entries.async_update_entry(config_entry, options=new)
+        hass.config_entries.async_update_entry(config_entry, options=new, version=5)
 
     #new 4.0.15
     #custom sensor for 'next x hours'
     if config_entry.version == 5:
         new = {**config_entry.options}
         new[CUSTOM_HOUR_SENSOR] = 1
-        config_entry.version = 6
-
-        hass.config_entries.async_update_entry(config_entry, options=new)
+        hass.config_entries.async_update_entry(config_entry, options=new, version=6)
 
     #new 4.0.16
     #which estimate value to use for data calcs est,est10,est90
     if config_entry.version == 6:
         new = {**config_entry.options}
         new[KEY_ESTIMATE] = "estimate"
-        config_entry.version = 7
-
-        hass.config_entries.async_update_entry(config_entry, options=new)
+        hass.config_entries.async_update_entry(config_entry, options=new, version=7)
 
     _LOGGER.debug("Solcast Migration to version %s successful", config_entry.version)
 

--- a/custom_components/solcast_solar/coordinator.py
+++ b/custom_components/solcast_solar/coordinator.py
@@ -34,7 +34,7 @@ class SolcastUpdateCoordinator(DataUpdateCoordinator):
     async def _async_update_data(self):
         """Update data via library."""
         return self.solcast._data
-            
+
     async def setup(self):
         d={}
         self._previousenergy = d
@@ -94,7 +94,7 @@ class SolcastUpdateCoordinator(DataUpdateCoordinator):
         elif key == "forecast_next_24hour":
             return self.solcast.get_forecast_n_hour(24)
         elif key == "total_kwh_forecast_tomorrow":
-            return self.solcast.get_total_kwh_forecast_day(1) 
+            return self.solcast.get_total_kwh_forecast_day(1)
         elif key == "total_kwh_forecast_d3":
             return self.solcast.get_total_kwh_forecast_day(2)
         elif key == "total_kwh_forecast_d4":
@@ -132,7 +132,7 @@ class SolcastUpdateCoordinator(DataUpdateCoordinator):
             return False if self.solcast._hardlimit == 100 else f"{round(self.solcast._hardlimit * 1000)}w"
         # elif key == "weather_description":
         #     return self.solcast.get_weather()
-        
+
 
         #just in case
         return None

--- a/custom_components/solcast_solar/manifest.json
+++ b/custom_components/solcast_solar/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/BJReplay/ha-solcast-solar/issues",
   "requirements": ["aiohttp>=3.8.5", "datetime>=4.3", "isodate>=0.6.1"],
-  "version": "4.0.27"
+  "version": "4.0.28"
 }

--- a/custom_components/solcast_solar/sensor.py
+++ b/custom_components/solcast_solar/sensor.py
@@ -44,7 +44,7 @@ SENSORS: dict[str, SensorEntityDescription] = {
         name="Forecast Today",
         icon="mdi:solar-power",
         suggested_display_precision=2,
-        #state_class= SensorStateClass.MEASUREMENT,
+        state_class= SensorStateClass.TOTAL,
     ),
     "peak_w_today": SensorEntityDescription(
         key="peak_w_today",
@@ -257,16 +257,15 @@ async def async_setup_entry(
                 suggested_display_precision=2,
                 rooftop_id=site["resource_id"],
             )
-        
         sen = RooftopSensor(
             key="site_data",
             coordinator=coordinator,
             entity_description=k,
             entry=entry,
         )
-        
+
         entities.append(sen)
-    
+
     async_add_entities(entities)
 
 class SolcastSensor(CoordinatorEntity, SensorEntity):
@@ -302,7 +301,12 @@ class SolcastSensor(CoordinatorEntity, SensorEntity):
                 f"SOLCAST - unable to get sensor value {ex} %s", traceback.format_exc()
             )
             self._sensor_data = None
-        
+
+        if self._sensor_data is None:
+            self._attr_available = False
+        else:
+            self._attr_available = True
+
         self._attr_device_info = {
             ATTR_IDENTIFIERS: {(DOMAIN, entry.entry_id)},
             ATTR_NAME: "Solcast PV Forecast", #entry.title,
@@ -349,12 +353,18 @@ class SolcastSensor(CoordinatorEntity, SensorEntity):
                 f"SOLCAST - unable to get sensor value {ex} %s", traceback.format_exc()
             )
             self._sensor_data = None
+
+        if self._sensor_data is None:
+            self._attr_available = False
+        else:
+            self._attr_available = True
+
         self.async_write_ha_state()
 
 @dataclass
 class RooftopSensorEntityDescription(SensorEntityDescription):
     rooftop_id: str | None = None
-    
+
 class RooftopSensor(CoordinatorEntity, SensorEntity):
     """Representation of a Solcast Sensor device."""
 
@@ -387,7 +397,7 @@ class RooftopSensor(CoordinatorEntity, SensorEntity):
                 f"SOLCAST - unable to get sensor value {ex} %s", traceback.format_exc()
             )
             self._sensor_data = None
-        
+
         self._attr_device_info = {
             ATTR_IDENTIFIERS: {(DOMAIN, entry.entry_id)},
             ATTR_NAME: "Solcast PV Forecast", #entry.title,
@@ -420,7 +430,7 @@ class RooftopSensor(CoordinatorEntity, SensorEntity):
         """Return the state extra attributes of the sensor."""
         try:
             return self.coordinator.get_site_sensor_extra_attributes(
-                self.rooftop_id, 
+                self.rooftop_id,
                 self.key,
             )
         except Exception as ex:
@@ -451,7 +461,7 @@ class RooftopSensor(CoordinatorEntity, SensorEntity):
         """Handle updated data from the coordinator."""
         try:
             self._sensor_data = self.coordinator.get_site_sensor_value(
-                self.rooftop_id, 
+                self.rooftop_id,
                 self.key,
             )
         except Exception as ex:

--- a/custom_components/solcast_solar/solcastapi.py
+++ b/custom_components/solcast_solar/solcastapi.py
@@ -159,6 +159,8 @@ class SolcastApi:
                                 async with aiofiles.open(apiCacheFileName) as f:
                                     resp_json = json.loads(await f.read())
                                     status = 200
+                            else:
+                                LOGGER.error(f"SOLCAST - cached sites data is not yet available to cope with Solcast API being too busy - at least one successful API call is needed")
 
                 if status == 200:
                     d = cast(dict, resp_json)
@@ -171,9 +173,10 @@ class SolcastApi:
 
                     self._sites = self._sites + d['sites']
                 else:
-                    _LOGGER.warning(
+                    _LOGGER.error(
                         f"SOLCAST - sites_data Solcast.com http status Error {status} - Gathering rooftop sites data"
                     )
+                    _LOGGER.error(f"SOLCAST - Solcast integration did not start correctly, as rooftop sites data is needed. Suggestion: Restart the integration")
                     raise Exception(f"SOLCAST - HTTP sites_data error: Solcast Error gathering rooftop sites data")
         except ConnectionRefusedError as err:
             _LOGGER.error("SOLCAST - sites_data ConnectionRefusedError Error.. %s",err)

--- a/info.md
+++ b/info.md
@@ -1,10 +1,38 @@
 ### Changes
 
+v4.0.28
+- Add retry for rooftop sites collection #12 by @autoSteve in https://github.com/BJReplay/ha-solcast-solar/pull/26
+- Full info.md changes since v4.0.25
+- Re-incorporate most v4.0.23 oziee changes by @autoSteve 
+- Retain cached data when API limit reached
+
+Full Changelog: https://github.com/BJReplay/ha-solcast-solar/compare/v4.0.27...v4.0.28
+
+New Collaborator
+
+- @autoSteve has made a huge contribution over the last few days - he has a sponsor button on his profile, so don't be afraid to mash it!
+
 v4.0.27
-- See: https://github.com/BJReplay/ha-solcast-solar/releases/tag/v4.0.27
+- docs: Update info.md by @Kolbi in https://github.com/BJReplay/ha-solcast-solar/pull/19
+- Use aiofiles with async open, await data_file by @autoSteve in https://github.com/BJReplay/ha-solcast-solar/pull/21
+- Add support for async_get_time_zone() by @autoSteve in https://github.com/BJReplay/ha-solcast-solar/pull/25
+
+Full Changelog: https://github.com/BJReplay/ha-solcast-solar/compare/v4.0.26...v4.0.27
+
+New Contributors
+- @Kolbi made their first contribution in https://github.com/BJReplay/ha-solcast-solar/pull/19
+- @autoSteve made their first contribution in https://github.com/BJReplay/ha-solcast-solar/pull/21
 
 v4.0.26
-- See: https://github.com/BJReplay/ha-solcast-solar/releases/tag/v4.0.26
+- Fixes #8 #9 #10 - My HA Button category by @mZ738 in https://github.com/BJReplay/ha-solcast-solar/pull/11
+- Update README.md by @wimdebruyn in https://github.com/BJReplay/ha-solcast-solar/pull/5
+- Prepare for new Release by @BJReplay in https://github.com/BJReplay/ha-solcast-solar/pull/13
+
+Full Changelog: https://github.com/BJReplay/ha-solcast-solar/compare/v4.0.25...v4.0.26
+ 
+New Contributors
+* @mZ738 made their first contribution in https://github.com/BJReplay/ha-solcast-solar/pull/11
+* @wimdebruyn made their first contribution in https://github.com/BJReplay/ha-solcast-solar/pull/5  
 
 v4.0.25
 - HACS Submission


### PR DESCRIPTION
Like the description says, on startup try for three times to get the rooftop sites, with five second waits, and if these fail then fall back on previously cached sites data.

If a rooftop sites gather had been previously successful then the data from that gather will be used with a warning issued in the log.

#12