### PR TITLE
Write API usage cache on every successful poll

### DIFF
--- a/custom_components/solcast_solar/manifest.json
+++ b/custom_components/solcast_solar/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/BJReplay/ha-solcast-solar/issues",
   "requirements": ["aiohttp>=3.8.5", "datetime>=4.3", "isodate>=0.6.1"],
-  "version": "4.0.28"
+  "version": "4.0.29"
 }

--- a/custom_components/solcast_solar/solcastapi.py
+++ b/custom_components/solcast_solar/solcastapi.py
@@ -125,7 +125,7 @@ class SolcastApi:
                         retries = 3
                         retry = retries
                         success = False
-                        while retry > 0:
+                        while retry >= 0:
                             resp: ClientResponse = await self.aiohttp_session.get(
                                 url=f"{self.options.host}/rooftop_sites", params=params, ssl=False
                             )
@@ -147,7 +147,7 @@ class SolcastApi:
                                 retry = 0
                                 success = True
                             else:
-                                if retry > 1:
+                                if retry > 0:
                                     _LOGGER.debug(f"SOLCAST - will retry GET rooftop_sites, retry {(retries - retry) + 1}")
                                     await asyncio.sleep(5)
                                 retry -= 1

--- a/custom_components/solcast_solar/solcastapi.py
+++ b/custom_components/solcast_solar/solcastapi.py
@@ -147,12 +147,13 @@ class SolcastApi:
                                 retry = 0
                                 success = True
                             else:
-                                _LOGGER.debug(f"SOLCAST - will retry GET rooftop_sites, retry {(retries - retry) + 1}")
-                                await asyncio.sleep(5)
+                                if retry > 1:
+                                    _LOGGER.debug(f"SOLCAST - will retry GET rooftop_sites, retry {(retries - retry) + 1}")
+                                    await asyncio.sleep(5)
                                 retry -= 1
                         if not success:
                             if statusTranslate.get(status): status = str(status) + statusTranslate[status]
-                            _LOGGER.warning(f"SOLCAST - Timeout gathering rooftop sites data, last call result: {status}, using cached data if it exists")
+                            _LOGGER.warning(f"SOLCAST - Retries exhausted gathering rooftop sites data, last call result: {status}, using cached data if it exists")
                             status = 404
                             if file_exists(apiCacheFileName):
                                 _LOGGER.debug(f"SOLCAST - loading cached sites data")

--- a/custom_components/solcast_solar/solcastapi.py
+++ b/custom_components/solcast_solar/solcastapi.py
@@ -724,6 +724,7 @@ class SolcastApi:
 
             async with async_timeout.timeout(480):
                 apiCacheFileName = cachedname + "_" + site + ".json"
+                usageCacheFileName = "solcast-usage.json"
                 if self.apiCacheEnabled and file_exists(apiCacheFileName):
                     _LOGGER.debug(f"SOLCAST - Getting cached testing data for site {site}")
                     status = 404
@@ -753,6 +754,9 @@ class SolcastApi:
                         if status == 200:
                             _LOGGER.debug(f"SOLCAST - API returned data. API Counter incremented from {self._api_used} to {self._api_used + 1}")
                             self._api_used = self._api_used + 1
+                            _LOGGER.debug(f"SOLCAST - writing usage cache")
+                            async with aiofiles.open(usageCacheFileName, 'w') as f:
+                                await f.write(json.dumps({"daily_limit": self._api_limit, "daily_limit_consumed": self._api_used}, ensure_ascii=False))
                         else:
                             _LOGGER.warning(f"SOLCAST - API returned status {status}. API used {self._api_used} to {self._api_used + 1}")
                             _LOGGER.warning("This is an error with the data returned from Solcast, not the integration")

--- a/custom_components/solcast_solar/solcastapi.py
+++ b/custom_components/solcast_solar/solcastapi.py
@@ -77,7 +77,7 @@ class SolcastApi:
         self._sites = []
         self._data = {'siteinfo': {}, 'last_updated': dt.fromtimestamp(0, timezone.utc).isoformat()}
         self._api_used = 0
-        self._api_limit = 0
+        self._api_limit = 10
         self._filename = options.file_path
         self._tz = options.tz
         self._dataenergy = {}

--- a/info.md
+++ b/info.md
@@ -1,5 +1,12 @@
 ### Changes
 
+v4.0.29
+- Bug fix: Write API usage cache on every successful poll by @autoSteve in https://github.com/BJReplay/ha-solcast-solar/pull/29
+- Bug fix: Default API limit to 10 to cope with initial call fail by @autoSteve
+- Increase sites GET retries from two to three by @autoSteve
+
+Full Changelog: https://github.com/BJReplay/ha-solcast-solar/compare/v4.0.28...v4.0.29
+
 v4.0.28
 - Add retry for rooftop sites collection #12 by @autoSteve in https://github.com/BJReplay/ha-solcast-solar/pull/26
 - Full info.md changes since v4.0.25


### PR DESCRIPTION
The number of API calls used is retrieved from Solcast on integration restart.  If this fails (due to site busy), then the usage cache is relied on to know how many calls have been made for the day.

This cache is not being updated when successful calls to get solar forecast are made, so this pull fixes that.

Thanks for pointing this out, @gcoan. #12.