### PR TITLE
Fix issue with multiple account sites caching

### DIFF
--- a/custom_components/solcast_solar/manifest.json
+++ b/custom_components/solcast_solar/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/BJReplay/ha-solcast-solar/issues",
   "requirements": ["aiohttp>=3.8.5", "datetime>=4.3", "isodate>=0.6.1"],
-  "version": "4.0.29"
+  "version": "4.0.30"
 }

--- a/custom_components/solcast_solar/solcastapi.py
+++ b/custom_components/solcast_solar/solcastapi.py
@@ -112,7 +112,10 @@ class SolcastApi:
                 #params = {"format": "json", "api_key": self.options.api_key}
                 params = {"format": "json", "api_key": spl.strip()}
                 async with async_timeout.timeout(60):
-                    apiCacheFileName = "solcast-sites.json"
+                    if len(sp) == 1:
+                        apiCacheFileName = "solcast-sites.json"
+                    else:
+                        apiCacheFileName = "solcast-sites-%s.json" % (spl,)
                     _LOGGER.debug(f"SOLCAST apiCacheEnabled={str(self.apiCacheEnabled)}, {apiCacheFileName}={str(file_exists(apiCacheFileName))}")
                     if self.apiCacheEnabled and file_exists(apiCacheFileName):
                         _LOGGER.debug(f"SOLCAST - loading cached sites data")
@@ -144,7 +147,7 @@ class SolcastApi:
                                 _LOGGER.debug(f"SOLCAST - writing sites data cache")
                                 async with aiofiles.open(apiCacheFileName, 'w') as f:
                                     await f.write(json.dumps(resp_json, ensure_ascii=False))
-                                retry = 0
+                                retry = -1
                                 success = True
                             else:
                                 if retry > 0:

--- a/info.md
+++ b/info.md
@@ -1,5 +1,11 @@
 ### Changes
 
+v4.0.30
+- Bug fix: Support multiple Solcast account sites caching
+- Bug fix: Retry mechanism when rooftop sites gather is actually successful was broken
+
+Full Changelog: https://github.com/BJReplay/ha-solcast-solar/compare/v4.0.29...v4.0.30
+
 v4.0.29
 - Bug fix: Write API usage cache on every successful poll by @autoSteve in https://github.com/BJReplay/ha-solcast-solar/pull/29
 - Bug fix: Default API limit to 10 to cope with initial call fail by @autoSteve


### PR DESCRIPTION
As the info.md says, @BJReplay

- Bug fix: Support multiple Solcast account sites caching
- Bug fix: Retry mechanism when rooftop sites gather is actually successful was broken
