### PR TITLE
Force all cache files to /config #43, track all account usage #42, prevent rapid forecast re-call #12

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ v4.0.32
 - Improve forecast fetch/retry logging debug, info, warning choice by @autoSteve
 - Suppression of consecutive forecast fetches within fifteen minutes (fixes strange mutliple fetches should a restart occur exactly when automation for fetch is triggered) by @autoSteve
 - Work-around: Prevent error when 'tally' is unavailable during retry by #autoSteve
+- Fix for earlier HA versions not recognising version= for async_update_entry() #40 by autoSteve
 
 Full Changelog: https://github.com/BJReplay/ha-solcast-solar/compare/v4.0.31...v4.0.32
 

--- a/README.md
+++ b/README.md
@@ -307,6 +307,18 @@ Modified from the great works of
 
 ## Changes
 
+v4.0.32
+- Bug fix: Independent API use counter for each Solcast account by @autoSteve
+- Bug fix: Force all caches to /config/ for all platforms (fixes Docker deployments) #43 by @autoSteve
+- Improve forecast fetch/retry logging debug, info, warning choice by @autoSteve
+- Suppression of consecutive forecast fetches within fifteen minutes (fixes strange mutliple fetches should a restart occur exactly when automation for fetch is triggered) by @autoSteve
+- Work-around: Prevent error when 'tally' is unavailable during retry by #autoSteve
+
+Full Changelog: https://github.com/BJReplay/ha-solcast-solar/compare/v4.0.31...v4.0.32
+
+Known issues
+- The variable 'tally' should never be unavailable during a forecast fetch retry sequence, but it can be for some reason. This causes site 'forecast today' sensor to show as 'Unknown' until the retries are exhausted, or a successful fetch occurs.
+
 v4.0.31
 - docs: Changes to README.md
 - docs: Add troubleshooting notes.

--- a/custom_components/solcast_solar/__init__.py
+++ b/custom_components/solcast_solar/__init__.py
@@ -101,7 +101,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     options = ConnectionOptions(
         entry.options[CONF_API_KEY],
         SOLCAST_URL,
-        hass.config.path('solcast.json'),
+        hass.config.path('/config/solcast.json'),
         tz,
         optdamp,
         entry.options[CUSTOM_HOUR_SENSOR],

--- a/custom_components/solcast_solar/coordinator.py
+++ b/custom_components/solcast_solar/coordinator.py
@@ -56,7 +56,8 @@ class SolcastUpdateCoordinator(DataUpdateCoordinator):
 
     async def update_utcmidnight_usage_sensor_data(self, *args):
         try:
-            self.solcast._api_used = 0
+            for k in self.solcast._api_used.keys():
+                self.solcast._api_used[k] = 0
             self.async_update_listeners()
         except Exception:
             #_LOGGER.error("SOLCAST - update_utcmidnight_usage_sensor_data: %s", traceback.format_exc())

--- a/custom_components/solcast_solar/manifest.json
+++ b/custom_components/solcast_solar/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/BJReplay/ha-solcast-solar/issues",
   "requirements": ["aiohttp>=3.8.5", "datetime>=4.3", "isodate>=0.6.1"],
-  "version": "4.0.31"
+  "version": "4.0.32"
 }

--- a/custom_components/solcast_solar/solcastapi.py
+++ b/custom_components/solcast_solar/solcastapi.py
@@ -113,9 +113,9 @@ class SolcastApi:
                 params = {"format": "json", "api_key": spl.strip()}
                 async with async_timeout.timeout(60):
                     if len(sp) == 1:
-                        apiCacheFileName = "solcast-sites.json"
+                        apiCacheFileName = "/config/solcast-sites.json"
                     else:
-                        apiCacheFileName = "solcast-sites-%s.json" % (spl,)
+                        apiCacheFileName = "/config/solcast-sites-%s.json" % (spl,)
                     _LOGGER.debug(f"SOLCAST apiCacheEnabled={str(self.apiCacheEnabled)}, {apiCacheFileName}={str(file_exists(apiCacheFileName))}")
                     if self.apiCacheEnabled and file_exists(apiCacheFileName):
                         _LOGGER.debug(f"SOLCAST - loading cached sites data")
@@ -204,9 +204,9 @@ class SolcastApi:
                 _LOGGER.debug(f"SOLCAST - getting API limit and usage from solcast for {sitekey}")
                 async with async_timeout.timeout(60):
                     if len(sp) == 1:
-                        apiCacheFileName = "solcast-usage.json"
+                        apiCacheFileName = "/config/solcast-usage.json"
                     else:
-                        apiCacheFileName = "solcast-usage-%s.json" % (spl,)
+                        apiCacheFileName = "/config/solcast-usage-%s.json" % (spl,)
                     resp: ClientResponse = await self.aiohttp_session.get(
                         url=f"https://api.solcast.com.au/json/reply/GetUserUsageAllowance", params=params, ssl=False
                     )
@@ -610,9 +610,9 @@ class SolcastApi:
             _LOGGER.debug(f"SOLCAST - API polling for rooftop {site['resource_id']}")
             #site=site['resource_id'], apikey=site['apikey'],
             if len(self._sites) == 1:
-                usageCacheFileName = "solcast-usage.json"
+                usageCacheFileName = "/config/solcast-usage.json"
             else:
-                usageCacheFileName = "solcast-usage-%s.json" % (site['apikey'],)
+                usageCacheFileName = "/config/solcast-usage-%s.json" % (site['apikey'],)
             result = await self.http_data_call(usageCacheFileName, site['resource_id'], site['apikey'], dopast)
             if not result:
                 failure = True
@@ -750,7 +750,7 @@ class SolcastApi:
             _LOGGER.debug(f"SOLCAST - fetch_data code url - {url}")
 
             async with async_timeout.timeout(480):
-                apiCacheFileName = cachedname + "_" + site + ".json"
+                apiCacheFileName = '/config/' + cachedname + "_" + site + ".json"
                 if self.apiCacheEnabled and file_exists(apiCacheFileName):
                     _LOGGER.debug(f"SOLCAST - Getting cached testing data for site {site}")
                     status = 404

--- a/custom_components/solcast_solar/solcastapi.py
+++ b/custom_components/solcast_solar/solcastapi.py
@@ -396,7 +396,8 @@ class SolcastApi:
 
     def get_rooftop_site_total_today(self, rooftopid) -> float:
         """Return a rooftop sites total kw for today"""
-        return self._data["siteinfo"][rooftopid]["tally"]
+        if self._data["siteinfo"][rooftopid].get("tally") == None: _LOGGER.warning(f"SOLCAST - 'Tally' is currently unavailable for rooftop {rooftopid}")
+        return self._data["siteinfo"][rooftopid].get("tally")
 
     def get_rooftop_site_extra_data(self, rooftopid = ""):
         """Return a rooftop sites information"""

--- a/custom_components/solcast_solar/solcastapi.py
+++ b/custom_components/solcast_solar/solcastapi.py
@@ -764,7 +764,7 @@ class SolcastApi:
                         counter = 1
                         backoff = 30
                         while counter <= 5:
-                            _LOGGER.debug(f"SOLCAST - Fetching forecast")
+                            _LOGGER.info(f"SOLCAST - Fetching forecast")
                             resp: ClientResponse = await self.aiohttp_session.get(
                                 url=url, params=params, ssl=False
                             )
@@ -773,7 +773,7 @@ class SolcastApi:
                             if status == 429:
                                 # Solcast is busy, so delay (30 seconds * counter), plus a random number of seconds between zero and 30
                                 delay = (counter * backoff) + random.randrange(0,30)
-                                _LOGGER.debug(f"SOLCAST - Solcast API is busy, pausing {delay} seconds before retry")
+                                _LOGGER.warning(f"SOLCAST - Solcast API is busy, pausing {delay} seconds before retry")
                                 await asyncio.sleep(delay)
                                 counter += 1
 
@@ -783,6 +783,7 @@ class SolcastApi:
                             _LOGGER.debug(f"SOLCAST - writing usage cache")
                             async with aiofiles.open(usageCacheFileName, 'w') as f:
                                 await f.write(json.dumps({"daily_limit": self._api_limit[apikey], "daily_limit_consumed": self._api_used[apikey]}, ensure_ascii=False))
+                            _LOGGER.info(f"SOLCAST - Fetch successful")
                         else:
                             _LOGGER.warning(f"SOLCAST - API returned status {status}. API used {self._api_used[apikey]} to {self._api_used[apikey] + 1}")
                             _LOGGER.warning("This is an error with the data returned from Solcast, not the integration")

--- a/custom_components/solcast_solar/solcastapi.py
+++ b/custom_components/solcast_solar/solcastapi.py
@@ -643,7 +643,7 @@ class SolcastApi:
             ae = None
             resp_dict = await self.fetch_data(usageCacheFileName, "estimated_actuals", 168, site=r_id, apikey=api, cachedname="actuals")
             if not isinstance(resp_dict, dict):
-                _LOGGER.warning(
+                _LOGGER.error(
                     f"SOLCAST - No data was returned for estimated_actuals so this WILL cause errors... "
                     f"Either your limit is exhaused, internet down, what ever the case is it is "
                     f"NOT a problem with the integration, and all other problems of sensor values being wrong will be seen"
@@ -784,15 +784,15 @@ class SolcastApi:
                             async with aiofiles.open(usageCacheFileName, 'w') as f:
                                 await f.write(json.dumps({"daily_limit": self._api_limit[apikey], "daily_limit_consumed": self._api_used[apikey]}, ensure_ascii=False))
                             _LOGGER.info(f"SOLCAST - Fetch successful")
+
+                            resp_json = await resp.json(content_type=None)
+
+                            if self.apiCacheEnabled:
+                                async with aiofiles.open(apiCacheFileName, 'w') as f:
+                                    await f.write(json.dumps(resp_json, ensure_ascii=False))
                         else:
                             _LOGGER.warning(f"SOLCAST - API returned status {status}. API used {self._api_used[apikey]} to {self._api_used[apikey] + 1}")
                             _LOGGER.warning("This is an error with the data returned from Solcast, not the integration")
-
-                        resp_json = await resp.json(content_type=None)
-
-                        if self.apiCacheEnabled:
-                            async with aiofiles.open(apiCacheFileName, 'w') as f:
-                                await f.write(json.dumps(resp_json, ensure_ascii=False))
                     else:
                         _LOGGER.warning(f"SOLCAST - API limit exceeded, not getting forecast")
                         return None

--- a/custom_components/solcast_solar/solcastapi.py
+++ b/custom_components/solcast_solar/solcastapi.py
@@ -330,7 +330,7 @@ class SolcastApi:
                                 del jsonData['siteinfo'][ll]
 
                             #create an up to date forecast and make sure the TZ fits just in case its changed
-                            await self.buildforcastdata()
+                            await self.buildforecastdata()
 
                 if not self._loaded_data:
                     #no file to load
@@ -624,7 +624,7 @@ class SolcastApi:
             #self._data["weather"] = self._weather
             self._loaded_data = True
 
-        await self.buildforcastdata()
+        await self.buildforecastdata()
         await self.serialize_data()
 
     async def http_data_call(self, usageCacheFileName, r_id = None, api = None, dopast = False):
@@ -851,7 +851,7 @@ class SolcastApi:
 
         return wh_hours
 
-    async def buildforcastdata(self):
+    async def buildforecastdata(self):
         """build the data needed and convert where needed"""
         try:
             today = dt.now(self._tz).date()


### PR DESCRIPTION
There's seemingly a lot going on here @BJReplay, which I had intended to split up, but GitHub desktop had different ideas.

There's the linuxserver Docker thing with /config/. #43

There's tracking API usage when one has multiple Solcast accounts. #42

And finally, there is a work-around for a weird occurrance that gcoan and I both hit, which I think is caused by restarting at exactly the same time that a get forecast is triggered by an automation. (Causes several consecutive forecast gets, chewing quota.) #12

I am still chasing the 'tally' thing in #42. So setting this as a draft.