### PR TITLE
Revert Ozzie state_class for sensor total kwh forecast

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,16 @@ Modified from the great works of
 * cjtapper/solcast-py
 * home-assistant-libs/forecast_solar
 
+## Known issues
+
+- The variable 'tally' should never be unavailable during a forecast fetch retry sequence, but it can be for some reason. This causes site 'forecast today' sensor to show as 'Unknown' until the retries are exhausted, or a successful fetch occurs.
+
 ## Changes
+
+v4.0.33
+- Revert Ozzie state_class for sensor total kwh forecast by @autoSteve
+
+Full Changelog: https://github.com/BJReplay/ha-solcast-solar/compare/v4.0.32...v4.0.33
 
 v4.0.32
 - Bug fix: Independent API use counter for each Solcast account by @autoSteve
@@ -316,9 +325,6 @@ v4.0.32
 - Fix for earlier HA versions not recognising version= for async_update_entry() #40 by autoSteve
 
 Full Changelog: https://github.com/BJReplay/ha-solcast-solar/compare/v4.0.31...v4.0.32
-
-Known issues
-- The variable 'tally' should never be unavailable during a forecast fetch retry sequence, but it can be for some reason. This causes site 'forecast today' sensor to show as 'Unknown' until the retries are exhausted, or a successful fetch occurs.
 
 v4.0.31
 - docs: Changes to README.md

--- a/custom_components/solcast_solar/manifest.json
+++ b/custom_components/solcast_solar/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/BJReplay/ha-solcast-solar/issues",
   "requirements": ["aiohttp>=3.8.5", "datetime>=4.3", "isodate>=0.6.1"],
-  "version": "4.0.32"
+  "version": "4.0.33"
 }

--- a/custom_components/solcast_solar/sensor.py
+++ b/custom_components/solcast_solar/sensor.py
@@ -44,7 +44,7 @@ SENSORS: dict[str, SensorEntityDescription] = {
         name="Forecast Today",
         icon="mdi:solar-power",
         suggested_display_precision=2,
-        state_class= SensorStateClass.TOTAL,
+        #state_class= SensorStateClass.TOTAL,
     ),
     "peak_w_today": SensorEntityDescription(
         key="peak_w_today",


### PR DESCRIPTION
@BJReplay, multiple users report loss of long-term statistics for versions featuring Oziee's 4.0.23 changes. I think it makes sense to revert one of his changes.