### PR TITLE
Ozzie reversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,11 +311,6 @@ Modified from the great works of
 
 ## Changes
 
-v4.0.33
-- Revert Ozzie state_class for sensor total kwh forecast by @autoSteve
-
-Full Changelog: https://github.com/BJReplay/ha-solcast-solar/compare/v4.0.32...v4.0.33
-
 v4.0.32
 - Bug fix: Independent API use counter for each Solcast account by @autoSteve
 - Bug fix: Force all caches to /config/ for all platforms (fixes Docker deployments) #43 by @autoSteve

--- a/custom_components/solcast_solar/__init__.py
+++ b/custom_components/solcast_solar/__init__.py
@@ -293,16 +293,8 @@ async def async_remove_config_entry_device(hass: HomeAssistant, entry: ConfigEnt
     return True
 
 async def async_update_options(hass: HomeAssistant, entry: ConfigEntry):
-    """Handle options update. Only reload if any item was changed"""
-    if any(
-        entry.data.get(attrib) != entry.options.get(attrib)
-        for attrib in (DAMP_FACTOR, HARD_LIMIT,KEY_ESTIMATE, CUSTOM_HOUR_SENSOR, CONF_API_KEY)
-    ):
-        # update entry replacing data with new options
-        hass.config_entries.async_update_entry(
-            entry, data={**entry.data, **entry.options}
-        )
-        await hass.config_entries.async_reload(entry.entry_id)
+    """Reload..."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Migrate old entry."""

--- a/custom_components/solcast_solar/manifest.json
+++ b/custom_components/solcast_solar/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/BJReplay/ha-solcast-solar/issues",
   "requirements": ["aiohttp>=3.8.5", "datetime>=4.3", "isodate>=0.6.1"],
-  "version": "4.0.33"
+  "version": "4.0.32"
 }

--- a/custom_components/solcast_solar/sensor.py
+++ b/custom_components/solcast_solar/sensor.py
@@ -44,7 +44,7 @@ SENSORS: dict[str, SensorEntityDescription] = {
         name="Forecast Today",
         icon="mdi:solar-power",
         suggested_display_precision=2,
-        #state_class= SensorStateClass.TOTAL,
+        state_class= SensorStateClass.TOTAL,
     ),
     "peak_w_today": SensorEntityDescription(
         key="peak_w_today",


### PR DESCRIPTION
I am killing the noise about the state_class, and also the draft v4.0.33 release.

It is what it is. And long-term statistics for forecasts are meaningless to anyone but Solcast themselves.

This pull is draft because it's likely that another Oziee change that is impacting dampening may need to come out. That and I don't want to forget to reinstate the state_class.