### PR TITLE
Breakdown of individual site forecast wattage and time as attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,8 @@ Click the Forecast option button and select the Solcast Solar option.. Click SAV
 > [!NOTE]
 > Where a site breakdown is available as an attribute, the attribute name is the Solcast site resource ID.
 >
-> Access these in a template sensor or automation using something like ```{{ state_attr('sensor.solcast_pv_forecast_peak_forecast_today', '1234-5678-9012-3456') }}```
+> Access these in a template sensor or automation using something like:
+> ```{{ state_attr('sensor.solcast_pv_forecast_peak_forecast_today', '1234-5678-9012-3456') }}```
 
 ### Configuration
 

--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ Click the Forecast option button and select the Solcast Solar option.. Click SAV
 > Where a site breakdown is available as an attribute, the attribute name is the Solcast site resource ID.
 >
 > Access these in a template sensor or automation using something like:
+>
 > ```{{ state_attr('sensor.solcast_pv_forecast_peak_forecast_today', '1234-5678-9012-3456') }}```
 
 ### Configuration

--- a/README.md
+++ b/README.md
@@ -264,18 +264,22 @@ Click the Forecast option button and select the Solcast Solar option.. Click SAV
 | `D5` | number | Y | `kWh` | Total forecast solar production for day + 4 (day 5) |
 | `D6` | number | Y | `kWh`| Total forecast solar production for day + 5 (day 6) |
 | `D7` | number | Y | `kWh` | Total forecast solar production for day + 6 (day 7) |
-| `This Hour` | number | N | `Wh` | Forecasted solar production current hour |
-| `Next Hour` | number | N | `Wh` | Forecasted solar production next hour |
+| `This Hour` | number | Y | `Wh` | Forecasted solar production current hour (attributes contain site breakdown) |
+| `Next Hour` | number | Y | `Wh` | Forecasted solar production next hour (attributes contain site breakdown) |
 | `Forecast Next X Hours` | number | N | `kWh` | Custom user defined X hour forecast |
 | `Remaining Today` | number | N | `kWh` | Predicted remaining solar production today |
-| `Peak Forecast Today` | number | N | `W` | Highest predicted production within an hour period today |
-| `Peak Time Today` | date/time | N |  | Hour of max forecasted production of solar today |
-| `Peak Forecast Tomorrow` | number | N | `W` | Highest predicted production within an hour period tomorrow |
-| `Peak Time Tomorrow` | date/time | N |  | Hour of max forecasted production of solar tomorrow |
-| `Power Now` | number | N | `W` | Power forecast during the current 0-30 / 30-59 min hour period |
-| `Power Next 30 Mins` | number | N | `W` | Power forecast for the next 30 min block period |
-| `Power Next Hour` | number | N | `W` | Power forecast for the next block 60 min from now |
+| `Peak Forecast Today` | number | Y | `W` | Highest predicted production within an hour period today (attributes contain site breakdown) |
+| `Peak Time Today` | date/time | Y |  | Hour of max forecasted production of solar today (attributes contain site breakdown) |
+| `Peak Forecast Tomorrow` | number | Y | `W` | Highest predicted production within an hour period tomorrow (attributes contain site breakdown) |
+| `Peak Time Tomorrow` | date/time | Y |  | Hour of max forecasted production of solar tomorrow (attributes contain site breakdown) |
+| `Power Now` | number | Y | `W` | Power forecast during the current 0-30 / 30-59 min hour period (attributes contain site breakdown) |
+| `Power Next 30 Mins` | number | Y | `W` | Power forecast for the next 30 min block period (attributes contain site breakdown) |
+| `Power Next Hour` | number | Y | `W` | Power forecast for the next block 60 min from now (attributes contain site breakdown) |
 
+> [!NOTE]
+> Where a site breakdown is available as an attribute, the attribute name is the Solcast site resource ID.
+>
+> Access these in a template sensor or automation using something like ```{{ state_attr('sensor.solcast_pv_forecast_peak_forecast_today', '1234-5678-9012-3456') }}```
 
 ### Configuration
 

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ Click the Forecast option button and select the Solcast Solar option.. Click SAV
 >
 > Access these in a template sensor or automation using something like:
 >
-> ```{{ state_attr('sensor.solcast_pv_forecast_peak_forecast_today', '1234-5678-9012-3456') }}```
+> ```{{ state_attr('sensor.solcast_pv_forecast_peak_forecast_today', '1234-5678-9012-3456') | float(0) }}```
 
 ### Configuration
 

--- a/custom_components/solcast_solar/coordinator.py
+++ b/custom_components/solcast_solar/coordinator.py
@@ -154,6 +154,12 @@ class SolcastUpdateCoordinator(DataUpdateCoordinator):
                 return self.solcast.get_forecast_day(5)
             case "total_kwh_forecast_d7":
                 return self.solcast.get_forecast_day(6)
+            case "power_now":
+                return self.solcast.get_sites_power_n_mins(0)
+            case "power_now_30m":
+                return self.solcast.get_sites_power_n_mins(30)
+            case "power_now_1hr":
+                return self.solcast.get_sites_power_n_mins(60)
             case "peak_w_today":
                 return self.solcast.get_sites_peak_w_day(0)
             case "peak_w_time_today":

--- a/custom_components/solcast_solar/coordinator.py
+++ b/custom_components/solcast_solar/coordinator.py
@@ -154,6 +154,14 @@ class SolcastUpdateCoordinator(DataUpdateCoordinator):
                 return self.solcast.get_forecast_day(5)
             case "total_kwh_forecast_d7":
                 return self.solcast.get_forecast_day(6)
+            case "peak_w_today":
+                return self.solcast.get_sites_peak_w_day(0)
+            case "peak_w_time_today":
+                return self.solcast.get_sites_peak_w_time_day(0)
+            case "peak_w_tomorrow":
+                return self.solcast.get_sites_peak_w_day(1)
+            case "peak_w_time_tomorrow":
+                return self.solcast.get_sites_peak_w_time_day(1)
             case _:
                 return None
 

--- a/custom_components/solcast_solar/solcastapi.py
+++ b/custom_components/solcast_solar/solcastapi.py
@@ -106,6 +106,7 @@ class SolcastApi:
         self._tz = options.tz
         self._dataenergy = {}
         self._data_forecasts = []
+        self._site_data_forecasts = {}
         self._forecasts_start_idx = 0
         self._detailedForecasts = []
         self._loaded_data = False
@@ -443,7 +444,7 @@ class SolcastApi:
         try:
             st_time = time.time()
 
-            st_i, end_i = self.get_forecast_list_slice(args[0], args[1], search_past=True)
+            st_i, end_i = self.get_forecast_list_slice(self._data_forecasts, args[0], args[1], search_past=True)
             h = self._data_forecasts[st_i:end_i]
 
             _LOGGER.debug("SOLCAST - get_forecast_list (%ss) st %s end %s st_i %d end_i %d h.len %d",
@@ -524,7 +525,7 @@ class SolcastApi:
 
         start_utc = self.get_day_start_utc() + timedelta(days=futureday)
         end_utc = start_utc + timedelta(days=1)
-        st_i, end_i = self.get_forecast_list_slice(start_utc, end_utc)
+        st_i, end_i = self.get_forecast_list_slice(self._data_forecasts, start_utc, end_utc)
         h = self._data_forecasts[st_i:end_i]
 
         _LOGGER.debug("SOLCAST - get_forecast_day %d st %s end %s st_i %d end_i %d h.len %d",
@@ -584,19 +585,29 @@ class SolcastApi:
         res = round(1000 * 1.5 * self.get_forecast_pv_estimates(start_utc, end_utc))
         return res
 
-    def get_peak_w_day(self, n_day) -> int:
+    def get_peak_w_day(self, n_day, site=None) -> int:
         """Return max kW for site N days ahead"""
         start_utc = self.get_day_start_utc() + timedelta(days=n_day)
         end_utc = start_utc + timedelta(days=1)
-        res = self.get_max_forecast_pv_estimate(start_utc, end_utc)
+        res = self.get_max_forecast_pv_estimate(start_utc, end_utc, site=site)
         return 0 if res is None else round(1000 * res[self._use_data_field])
 
-    def get_peak_w_time_day(self, n_day) -> dt:
+    def get_peak_w_time_day(self, n_day, site=None) -> dt:
         """Return hour of max kW for site N days ahead"""
         start_utc = self.get_day_start_utc() + timedelta(days=n_day)
         end_utc = start_utc + timedelta(days=1)
-        res = self.get_max_forecast_pv_estimate(start_utc, end_utc)
+        res = self.get_max_forecast_pv_estimate(start_utc, end_utc, site=site)
         return res if res is None else res["period_start"]
+
+    def get_sites_peak_w_day(self, n_day) -> Dict[str, Any]:
+        res = {}
+        for site in self._sites: res[site['resource_id']] = self.get_peak_w_day(n_day, site['resource_id'])
+        return res
+
+    def get_sites_peak_w_time_day(self, n_day) -> Dict[str, Any]:
+        res = {}
+        for site in self._sites: res[site['resource_id']] = self.get_peak_w_time_day(n_day, site['resource_id'])
+        return res
 
     def get_forecast_remaining_today(self) -> float:
         """Return remaining Forecasts data for today"""
@@ -613,13 +624,13 @@ class SolcastApi:
         res = 0.5 * self.get_forecast_pv_estimates(start_utc, end_utc)
         return res
 
-    def get_forecast_list_slice(self, start_utc, end_utc, search_past=False):
+    def get_forecast_list_slice(self, _data, start_utc, end_utc, search_past=False):
         """Return Solcast pv_estimates list slice [st_i, end_i) for interval [start_utc, end_utc)"""
         crt_i = -1
         st_i = -1
-        end_i = len(self._data_forecasts)
+        end_i = len(_data)
         for crt_i in range(0 if search_past else self._forecasts_start_idx, end_i):
-            d = self._data_forecasts[crt_i]
+            d = _data[crt_i]
             d1 = d['period_start']
             d2 = d1 + timedelta(seconds=1800)
             # after the last segment
@@ -639,7 +650,7 @@ class SolcastApi:
         """Return Solcast pv_estimates for interval [start_utc, end_utc)"""
         try:
             res = 0
-            st_i, end_i = self.get_forecast_list_slice(start_utc, end_utc)
+            st_i, end_i = self.get_forecast_list_slice(self._data_forecasts, start_utc, end_utc)
             for d in self._data_forecasts[st_i:end_i]:
                 d1 = d['period_start']
                 d2 = d1 + timedelta(seconds=1800)
@@ -662,11 +673,30 @@ class SolcastApi:
             _LOGGER.error(f"SOLCAST - get_forecast_pv_estimates: {ex}")
             return 0
 
+    def get_max_forecast_pv_estimate(self, start_utc, end_utc, site=None):
+        """Return max Solcast pv_estimate for the interval [start_utc, end_utc)"""
+        try:
+            _data = self._data_forecasts if site is None else self._site_data_forecasts[site]
+            res = None
+            st_i, end_i = self.get_forecast_list_slice(_data, start_utc, end_utc)
+            for d in _data[st_i:end_i]:
+                if res is None or res[self._use_data_field] < d[self._use_data_field]:
+                    res = d
+            _LOGGER.debug("SOLCAST - %s st %s end %s st_i %d end_i %d res %s",
+                          currentFuncName(1),
+                          start_utc.strftime('%Y-%m-%d %H:%M:%S'),
+                          end_utc.strftime('%Y-%m-%d %H:%M:%S'),
+                          st_i, end_i, res)
+            return res
+        except Exception as ex:
+            _LOGGER.error(f"SOLCAST - get_max_forecast_pv_estimate: {ex}")
+            return None
+    '''
     def get_max_forecast_pv_estimate(self, start_utc, end_utc):
         """Return max Solcast pv_estimate for the interval [start_utc, end_utc)"""
         try:
             res = None
-            st_i, end_i = self.get_forecast_list_slice(start_utc, end_utc)
+            st_i, end_i = self.get_forecast_list_slice(self._data_forecasts, start_utc, end_utc)
             for d in self._data_forecasts[st_i:end_i]:
                 if res is None or res[self._use_data_field] < d[self._use_data_field]:
                     res = d
@@ -679,6 +709,7 @@ class SolcastApi:
         except Exception as ex:
             _LOGGER.error(f"SOLCAST - get_max_forecast_pv_estimate: {ex}")
             return None
+    '''
 
     def get_energy_data(self) -> dict[str, Any]:
         try:
@@ -952,6 +983,8 @@ class SolcastApi:
             st_time = time.time()
             for site, siteinfo in self._data['siteinfo'].items():
                 tally = 0
+                _site_fcasts_dict = {}
+
                 for x in siteinfo['forecasts']:
                     #loop each site and its forecasts
                     z = x["period_start"]
@@ -964,6 +997,7 @@ class SolcastApi:
                         if zz.date() == today:
                             tally += min(x[self._use_data_field] * 0.5 * self._damp[h], self._hardlimit)
 
+                        # add the dampened forecast for this site to the total
                         itm = _fcasts_dict.get(z)
                         if itm:
                             itm["pv_estimate"] = min(round(itm["pv_estimate"] + (x["pv_estimate"] * self._damp[h]),4), self._hardlimit)
@@ -974,6 +1008,13 @@ class SolcastApi:
                                                 "pv_estimate": min(round((x["pv_estimate"]* self._damp[h]),4), self._hardlimit),
                                                 "pv_estimate10": min(round((x["pv_estimate10"]* self._damp[h]),4), self._hardlimit),
                                                 "pv_estimate90": min(round((x["pv_estimate90"]* self._damp[h]),4), self._hardlimit)}
+
+                        # record the individual site forecast
+                        _site_fcasts_dict[z] = {"period_start": z,
+                                            "pv_estimate": min(round((x["pv_estimate"]* self._damp[h]),4), self._hardlimit),
+                                            "pv_estimate10": min(round((x["pv_estimate10"]* self._damp[h]),4), self._hardlimit),
+                                            "pv_estimate90": min(round((x["pv_estimate90"]* self._damp[h]),4), self._hardlimit)}
+                self._site_data_forecasts[site] = sorted(_site_fcasts_dict.values(), key=itemgetter("period_start"))
 
                 siteinfo['tally'] = round(tally, 4)
                 self._tally[site] = siteinfo['tally']
@@ -1006,7 +1047,7 @@ class SolcastApi:
         for i in range(0,8):
             start_utc = self.get_day_start_utc() + timedelta(days=i)
             end_utc = start_utc + timedelta(days=1)
-            st_i, end_i = self.get_forecast_list_slice(start_utc, end_utc)
+            st_i, end_i = self.get_forecast_list_slice(self._data_forecasts, start_utc, end_utc)
             num_rec = end_i - st_i
 
             da = dt.now(self._tz).date() + timedelta(days=i)

--- a/custom_components/solcast_solar/solcastapi.py
+++ b/custom_components/solcast_solar/solcastapi.py
@@ -669,8 +669,9 @@ class SolcastApi:
                 if s < 1800:
                     f *= s / 1800
                 res += f
-            _LOGGER.debug("SOLCAST - %s st %s end %s st_i %d end_i %d res %s",
+            _LOGGER.debug("SOLCAST - %s%s st %s end %s st_i %d end_i %d res %s",
                           currentFuncName(1),
+                          '' if site is None else ' '+site,
                           start_utc.strftime('%Y-%m-%d %H:%M:%S'),
                           end_utc.strftime('%Y-%m-%d %H:%M:%S'),
                           st_i, end_i, round(res,3))
@@ -688,8 +689,9 @@ class SolcastApi:
             for d in _data[st_i:end_i]:
                 if res is None or res[self._use_data_field] < d[self._use_data_field]:
                     res = d
-            _LOGGER.debug("SOLCAST - %s st %s end %s st_i %d end_i %d res %s",
+            _LOGGER.debug("SOLCAST - %s%s st %s end %s st_i %d end_i %d res %s",
                           currentFuncName(1),
+                          '' if site is None else ' '+site,
                           start_utc.strftime('%Y-%m-%d %H:%M:%S'),
                           end_utc.strftime('%Y-%m-%d %H:%M:%S'),
                           st_i, end_i, res)

--- a/custom_components/solcast_solar/solcastapi.py
+++ b/custom_components/solcast_solar/solcastapi.py
@@ -691,25 +691,6 @@ class SolcastApi:
         except Exception as ex:
             _LOGGER.error(f"SOLCAST - get_max_forecast_pv_estimate: {ex}")
             return None
-    '''
-    def get_max_forecast_pv_estimate(self, start_utc, end_utc):
-        """Return max Solcast pv_estimate for the interval [start_utc, end_utc)"""
-        try:
-            res = None
-            st_i, end_i = self.get_forecast_list_slice(self._data_forecasts, start_utc, end_utc)
-            for d in self._data_forecasts[st_i:end_i]:
-                if res is None or res[self._use_data_field] < d[self._use_data_field]:
-                    res = d
-            _LOGGER.debug("SOLCAST - %s st %s end %s st_i %d end_i %d res %s",
-                          currentFuncName(1),
-                          start_utc.strftime('%Y-%m-%d %H:%M:%S'),
-                          end_utc.strftime('%Y-%m-%d %H:%M:%S'),
-                          st_i, end_i, res)
-            return res
-        except Exception as ex:
-            _LOGGER.error(f"SOLCAST - get_max_forecast_pv_estimate: {ex}")
-            return None
-    '''
 
     def get_energy_data(self) -> dict[str, Any]:
         try:


### PR DESCRIPTION
This PR adds a breakdown of individual site peak forecast wattage and time to the attributes of:

* sensor.solcast_pv_forecast_peak_forecast_today
* sensor.solcast_pv_forecast_peak_forecast_tomorrow
* sensor.solcast_pv_forecast_peak_time_today
* sensor.solcast_pv_forecast_peak_time_tomorrow
* sensor.solcast_pv_forecast_power_now
* sensor.solcast_pv_forecast_power_next_30_mins
* sensor.solcast_pv_forecast_power_next_hour

Attribute name is the Solcast site resource ID.

Feature request #64 by @gcoan.