### PR TITLE
Add info about preserving oziee history and config to banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
 > Collaborators are welcome, as are PRs for enhancements.
 >
 > Bug reports unrelated to API changes may not get the attention you want, as the the repository owner is largely retired for medical reasons, but knows the Solcast API as a former / user in this and other projects.
+>
+> This integration can be used as a replacement for the original oziee/ha-solcast-solar integration. Uninstalling the oziee version then installing this one will preserve the history and configuration from the oziee integration.
 
 Version Change Notes: See [below](#changes).
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,11 @@
 > Collaborators are welcome, as are PRs for enhancements.
 >
 > Bug reports unrelated to API changes may not get the attention you want, as the the repository owner is largely retired for medical reasons, but knows the Solcast API as a former / user in this and other projects.
+
+> [!NOTE]
+> This integration can be used as a replacement for the oziee/ha-solcast-solar integration, which has been removed from GitHub and HACS.  
 >
-> This integration can be used as a replacement for the original oziee/ha-solcast-solar integration. Uninstalling the oziee version then installing this one will preserve the history and configuration from the oziee integration.
+> Uninstalling the oziee version then installing this one will preserve the history and configuration from the oziee integration.
 
 Version Change Notes: See [below](#changes).
 


### PR DESCRIPTION
This adds what I feel is a key bit of info to the banner about moving to this repo from the original integration, as I spent a while looking around trying to confirm this info before finding it part way down the page in the manual HACS install section.

Feel free to reword if you like :)