### PR TITLE
Post v4.0.41

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,26 +250,27 @@ mode: single
 ```
 
 > [!TIP]
-> The Solcast Servers seem to occasionally be under some strain, and the servers return 429 return codes when they are busy.
-> The Solcast integration will automatically pause, then retry the connection several times, but occasionally even this strategy can fail to download Solcast data.
-> Changing your API Key is not a solution, nor is uninstalling and re-installing the Solcast PV Solar Integration.
-> These "tricks" might appear to work, but all that has actually happened is that you have tried again later, and the integration has worked as the Solcast servers are less busy.
+> The Solcast Servers seem to occasionally be under some strain, and the servers return 429/Too busy return codes at these times. The integration will automatically pause, then retry the connection several times, but occasionally even this strategy can fail to download forecast data.
+>
+> Changing your API Key is not a solution, nor is uninstalling and re-installing the integration. These "tricks" might appear to work, but all that has actually happened is that you have tried again later, and the integration has worked as the Solcast servers are less busy.
 > 
-> If you think that have problems in the integration, make sure that you have logging turned on, and capture logs to find out if you are getting messages indicating that the Solcast API is busy - these indicate that the Solcast API is under stress.
-> Log capture instructions are in the Bug Issue Template - you will see them if you start creating a new issue - make sure you include logs if you want the assistance of the repository constributors.
-> An example of busy messages and a retry are shown below.
+> To find out whether this is your issue look at the Home Assistant logs. To get detailed information (which is required when raising an issue) make sure that you have debug logging turned on.
+>
+> Log capture instructions are in the Bug Issue Template - you will see them if you start creating a new issue - make sure you include these logs if you want the assistance of the repository constributors.
+>
+> An example of busy messages and a successful retry are shown below (with debug logging enabled). In this case there is no issue, as the retry succeeds. Should five consecutive attempts fail, then the forecast retrieval will end with an `ERROR`. If that happens, manually trigger another `solcast_solar.update_forecasts` service call, or wait for your next scheduled automation run. A reload of the integration might also be needed in some cases, should the load of sites data on integration startup be the call that has failed with 429/Too busy.
 
 ```
-homeassistant  | 2024-06-17 09:34:22.403 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] SOLCAST - API polling for rooftop 1234-5678-9012-3456
-homeassistant  | 2024-06-17 09:34:22.403 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] SOLCAST - Polling API for rooftop_id 1234-5678-9012-3456
-homeassistant  | 2024-06-17 09:34:22.403 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] SOLCAST - fetch_data code url - https://api.solcast.com.au/rooftop_sites/1234-5678-9012-3456/forecasts
-homeassistant  | 2024-06-17 09:34:22.403 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] SOLCAST - Fetching forecast
-homeassistant  | 2024-06-17 09:34:22.549 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] SOLCAST - Solcast API is busy, pausing 55 seconds before retry
-homeassistant  | 2024-06-17 09:35:17.552 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] SOLCAST - Fetching forecast
-homeassistant  | 2024-06-17 09:35:18.065 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] SOLCAST - API returned data. API Counter incremented from 35 to 36
-homeassistant  | 2024-06-17 09:35:18.065 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] SOLCAST - writing usage cache
-homeassistant  | 2024-06-17 09:35:18.089 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] SOLCAST - fetch_data code http_session returned data type is <class 'dict'>
-homeassistant  | 2024-06-17 09:35:18.090 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] SOLCAST - fetch_data code http_session status is 200
+INFO (MainThread) [custom_components.solcast_solar.solcastapi] Getting forecast update for Solcast site 1234-5678-9012-3456
+DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] Polling API for rooftop_id 1234-5678-9012-3456
+DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] Fetch data url - https://api.solcast.com.au/rooftop_sites/1234-5678-9012-3456/forecasts
+DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] Fetching forecast
+WARNING (MainThread) [custom_components.solcast_solar.solcastapi] Solcast API is busy, pausing 55 seconds before retry
+DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] Fetching forecast
+DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] API returned data. API Counter incremented from 35 to 36
+DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] Writing usage cache
+DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] HTTP ssession returned data type in fetch_data() is <class 'dict'>
+DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] HTTP session status in fetch_data() is 200/Success
 ```
 
 <summary><h3>Set up HA Energy Dashboard settings</summary></h3>

--- a/README.md
+++ b/README.md
@@ -201,9 +201,9 @@ mode: single
 ```
 
 > [!NOTE]  
-> If you have two arrays on your roof then 2 api calls will be made for each update, effectively reducing the number of updates to 5 per day. For this case, change to: `api_request_limit = 5`
+> If you have two arrays on your roof then two api calls will be made for each update, effectively reducing the number of updates to five per day. For this case, change to: `api_request_limit = 5`
 
-The next automation also includes a rendomisation so that calls aren't made at precisely the same time, hopefully avoiding the likelihood that the Solcast servers are inundated by multiple calls at the same time, but it triggers every four hours between sunrise and sunset:
+The next automation also includes a randomisation so that calls aren't made at precisely the same time, hopefully avoiding the likelihood that the Solcast servers are inundated by multiple calls at the same time, but it triggers every four hours between sunrise and sunset:
 
 ```yaml
 alias: Solcast_update
@@ -497,7 +497,7 @@ v4.0.41
 * Interpolated forecast 0/30/60 fix #101 by @autoSteve
 * Ensure config directory is always relative to install location #98 by @autoSteve
 * Add state_class to `power_now_30m` and `power_now_1hr` to match `power_now` by @autoSteve (will remove LTS, but LTS is not useful for these sensors)
-* Utilise daily splines of momentatry and reducing forecast values by @autoSteve
+* Utilise daily splines of momentary and reducing forecast values by @autoSteve
 
 Full Changelog: https://github.com/BJReplay/ha-solcast-solar/compare/v4.0.40...v4.0.41
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Many users will not use these attributes, so to cut the clutter (especially in t
 By default, all of them are enabled. (NB: Hourly and half-hourly detail is already excluded from being sent to LTS.)
 
 > [!NOTE]
-> If you want to implement the sample PV graph below then you'll need to keep half-hourly detail breakdown enabled.
+> If you want to implement the sample PV graph below then you'll need to keep half-hourly detail breakdown enabled, along with `estimate10`.
 
 ## Key Solcast concepts
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,11 @@ Here you can change the dampening factor value for any hour. Values from 0.0 - 1
 
 [<img src="https://github.com/BJReplay/ha-solcast-solar/blob/v3/.github/SCREENSHOTS/dampopt.png" width="200">](https://github.com/BJReplay/ha-solcast-solar/blob/v3/.github/SCREENSHOTS/dampopt.png)
 
+> [!TIP]
+> Most users of dampening configuration do not enter values in the configuration settings directly. Rather, they build automations to set values that are appropriate for their location at different days or seasons, and these call the `solcast_solar_set_dampening` service.
+>
+> Factors causing dampening to be appropriate might be when different degrees of shading occur at the start or end of a day in Winter only, where the sun is closer to the horizon and might cause nearby buildings or trees to cast a longer shadow than in other seasons.
+
 ## Sensor Attributes Configuration
 
 New in v4.0.39 is the option to turn off many sensor attributes.

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Here you can change the dampening factor value for any hour. Values from 0.0 - 1
 [<img src="https://github.com/BJReplay/ha-solcast-solar/blob/v3/.github/SCREENSHOTS/dampopt.png" width="200">](https://github.com/BJReplay/ha-solcast-solar/blob/v3/.github/SCREENSHOTS/dampopt.png)
 
 > [!TIP]
-> Most users of dampening configuration do not enter values in the configuration settings directly. Rather, they build automations to set values that are appropriate for their location at different days or seasons, and these call the `solcast_solar_set_dampening` service.
+> Most users of dampening configuration do not enter values in the configuration settings directly. Rather, they build automations to set values that are appropriate for their location at different days or seasons, and these call the `solcast_solar.set_dampening` service.
 >
 > Factors causing dampening to be appropriate might be when different degrees of shading occur at the start or end of a day in Winter only, where the sun is closer to the horizon and might cause nearby buildings or trees to cast a longer shadow than in other seasons.
 

--- a/custom_components/solcast_solar/coordinator.py
+++ b/custom_components/solcast_solar/coordinator.py
@@ -45,11 +45,11 @@ class SolcastUpdateCoordinator(DataUpdateCoordinator):
         self._previousenergy = d
         self._lastDay = dt.now(self.solcast._tz).day
         try:
+            #4.0.41 - recalculate splines at midnight local
+            async_track_time_change(self._hass, self.update_midnight_spline_recalc, hour=0,minute=0,second=0)
             #4.0.18 - added reset usage call to reset usage sensors at UTC midnight
             async_track_utc_time_change(self._hass, self.update_utcmidnight_usage_sensor_data, hour=0,minute=0,second=0)
             async_track_utc_time_change(self._hass, self.update_integration_listeners, minute=range(0, 60, 5), second=0)
-            #4.0.41 - recalculate splines at midnight local
-            async_track_time_change(self._hass, self.update_midnight_spline_recalc, hour=0,minute=0,second=0)
         except Exception as error:
             _LOGGER.error("Exception in Solcast coordinator setup: %s", traceback.format_exc())
 

--- a/custom_components/solcast_solar/solcastapi.py
+++ b/custom_components/solcast_solar/solcastapi.py
@@ -768,6 +768,8 @@ class SolcastApi:
             for j in xx:
                 i = int(j/300)
                 if math.copysign(1.0, self.fc_moment['all'][_data_field][i]) < 0: self.fc_moment['all'][_data_field][i] = 0.0 # Suppress negative values
+                k = int(math.floor(j/1800))
+                if k+1 <= len(y)-1 and y[k] == 0 and y[k+1] == 0: self.fc_moment['all'][_data_field][i] = 0.0 # Suppress spline bounce
         if self.options.attr_brk_site:
             for site in self._sites:
                 self.fc_moment[site['resource_id']] = {}
@@ -779,6 +781,8 @@ class SolcastApi:
                     for j in xx:
                         i = int(j/300)
                         if math.copysign(1.0, self.fc_moment[site['resource_id']][_data_field][i]) < 0: self.fc_moment[site['resource_id']][_data_field][i] = 0.0 # Suppress negative values
+                        k = int(math.floor(j/1800))
+                        if k+1 <= len(y)-1 and y[k] == 0 and y[k+1] == 0: self.fc_moment[site['resource_id']][_data_field][i] = 0.0 # Suppress spline bounce
 
     def get_moment(self, site, _data_field, t):
         return self.fc_moment['all' if site is None else site][self._data_field if _data_field is None else _data_field][int(t / 300)]


### PR DESCRIPTION
* Readme typo fixes and updates
* Suppress spline bounce for 'moment' splines re. forecast 0/+30/+60 going positive before/after day start/end
* Initial try at ensuring splines are calculated at midnight local before sensors update (callback registering change order, might not work given the async nature of those updates, but seems to be working)
* Clarification that the `estimate10` attributes are required for the example Apex chart to work