### PR TITLE
Initial sites load fail report and HA retries

### DIFF
--- a/custom_components/solcast_solar/solcastapi.py
+++ b/custom_components/solcast_solar/solcastapi.py
@@ -107,6 +107,7 @@ class SolcastApi:
         self.aiohttp_session = aiohttp_session
         self.options = options
         self.apiCacheEnabled = apiCacheEnabled
+        self._sites_loaded = False
         self._sites = []
         self._data = {'siteinfo': {}, 'last_updated': dt.fromtimestamp(0, timezone.utc).isoformat()}
         self._tally = {}
@@ -258,6 +259,7 @@ class SolcastApi:
                         i.pop('longitude', None)
                         i.pop('latitude', None)
                     self._sites = self._sites + d['sites']
+                    self._sites_loaded = True
                 else:
                     _LOGGER.error(f"{self.options.host} HTTP status error {translate(status)} in sites_data() while gathering sites")
                     _LOGGER.error(f"Solcast integration did not start correctly, as site(s) are needed. Suggestion: Restart the integration")
@@ -285,6 +287,7 @@ class SolcastApi:
                                 i.pop('longitude', None)
                                 i.pop('latitude', None)
                             self._sites = self._sites + d['sites']
+                            self._sites_loaded = True
                             _LOGGER.info(f"Loaded sites cache for {self.redact_api_key(spl)}")
                     else:
                         error = True

--- a/custom_components/solcast_solar/solcastapi.py
+++ b/custom_components/solcast_solar/solcastapi.py
@@ -262,7 +262,6 @@ class SolcastApi:
                     self._sites_loaded = True
                 else:
                     _LOGGER.error(f"{self.options.host} HTTP status error {translate(status)} in sites_data() while gathering sites")
-                    _LOGGER.error(f"Solcast integration did not start correctly, as site(s) are needed. Suggestion: Restart the integration")
                     raise Exception(f"HTTP sites_data error: Solcast Error gathering sites")
         except ConnectionRefusedError as err:
             _LOGGER.error("Connection refused in sites_data(): %s", err)
@@ -292,10 +291,10 @@ class SolcastApi:
                     else:
                         error = True
                         _LOGGER.error(f"Cached sites are not yet available for {self.redact_api_key(spl)} to cope with Solcast API call failure")
-                        _LOGGER.error(f"At least one successful API 'get sites' call is needed, so the integration cannot function")
+                        _LOGGER.error(f"At least one successful API 'get sites' call is needed, so the integration cannot function yet")
                 if error:
                     _LOGGER.error("Timed out getting Solcast sites, and one or more site caches failed to load")
-                    _LOGGER.error("This is critical, and the integration cannot function reliably")
+                    _LOGGER.error("This is critical, and the integration cannot function reliably yet")
                     _LOGGER.error("Suggestion: Double check your overall HA configuration, specifically networking related")
             except Exception as e:
                 pass


### PR DESCRIPTION
Hey @BJReplay.

This PR is a change to the way that the integration loads to make it more robust.

In the past, should the Solcast sites not be able to be retrieved from the API, or the cache we would just log a bunch of foul messages about attempting integration reload until it worked. I have never been comfortable with this approach.

What this change does is to fail the integration load with a message about sites not being able to be retrieved, raising ConfigEntryNotReady(), and this in turn instructs Home Assistant to do its retry thing repeatedly until async_setup_entry() reports `True`.

To test this I killed my solcast-sites.json file, and restarted the integration around the bottom of the hour. Sure enough it could not load the sites on three retries with 429s. Then it tried, and failed again. Then it tried again, and on that third set of attempts it managed to retrieve the sites and move on. The whole sequence took about one minute and was totally hands-off.

New users will be delighted with this change, and we will hopefully be delighted by even less issue reports.

```
2024-08-03 16:30:25.452 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] Configuration directory is /config
2024-08-03 16:30:25.452 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] Sites cache does not yet exist
2024-08-03 16:30:25.452 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] Connecting to https://api.solcast.com.au/rooftop_sites?format=json&api_key=******NV8ggJ
2024-08-03 16:30:25.462 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] HTTP session returned status 429/Solcast too busy in sites_data()
2024-08-03 16:30:25.462 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] Will retry get sites, retry 1
2024-08-03 16:30:30.474 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] HTTP session returned status 429/Solcast too busy in sites_data()
2024-08-03 16:30:30.474 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] Will retry get sites, retry 2
2024-08-03 16:30:35.486 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] HTTP session returned status 429/Solcast too busy in sites_data()
2024-08-03 16:30:35.486 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] Will retry get sites, retry 3
2024-08-03 16:30:40.499 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] HTTP session returned status 429/Solcast too busy in sites_data()
2024-08-03 16:30:40.499 WARNING (MainThread) [custom_components.solcast_solar.solcastapi] Retries exhausted gathering Solcast sites, last call result: 429/Solcast too busy, using cached data if it exists
2024-08-03 16:30:40.499 ERROR (MainThread) [custom_components.solcast_solar.solcastapi] Cached Solcast sites are not yet available for ******NV8ggJ to cope with API call failure
2024-08-03 16:30:40.499 ERROR (MainThread) [custom_components.solcast_solar.solcastapi] At least one successful API 'get sites' call is needed, so the integration will not function correctly
2024-08-03 16:30:40.499 ERROR (MainThread) [custom_components.solcast_solar.solcastapi] https://api.solcast.com.au HTTP status error 404/Not found in sites_data() while gathering sites
2024-08-03 16:30:40.500 ERROR (MainThread) [custom_components.solcast_solar.solcastapi] Solcast integration did not start correctly, as site(s) are needed. Suggestion: Restart the integration
2024-08-03 16:30:40.503 ERROR (MainThread) [custom_components.solcast_solar.solcastapi] Exception in sites_data(): Traceback (most recent call last):
  File "/config/custom_components/solcast_solar/solcastapi.py", line 266, in sites_data
    raise Exception(f"HTTP sites_data error: Solcast Error gathering sites")
Exception: HTTP sites_data error: Solcast Error gathering sites

2024-08-03 16:30:40.503 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] Getting API limit and usage from solcast for ******NV8ggJ
2024-08-03 16:30:40.503 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] API usage cache exists
2024-08-03 16:30:40.512 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] HTTP session returned status 429/Solcast too busy in sites_usage()
2024-08-03 16:30:40.514 INFO (MainThread) [custom_components.solcast_solar.solcastapi] Loaded API usage cache
2024-08-03 16:30:40.514 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] API counter for ******NV8ggJ is 4/10
2024-08-03 16:30:45.661 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] Configuration directory is /config
2024-08-03 16:30:45.661 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] Sites cache does not yet exist
2024-08-03 16:30:45.661 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] Connecting to https://api.solcast.com.au/rooftop_sites?format=json&api_key=******NV8ggJ
2024-08-03 16:30:45.673 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] HTTP session returned status 429/Solcast too busy in sites_data()
2024-08-03 16:30:45.673 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] Will retry get sites, retry 1
2024-08-03 16:30:50.682 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] HTTP session returned status 429/Solcast too busy in sites_data()
2024-08-03 16:30:50.682 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] Will retry get sites, retry 2
2024-08-03 16:30:55.694 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] HTTP session returned status 429/Solcast too busy in sites_data()
2024-08-03 16:30:55.694 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] Will retry get sites, retry 3
2024-08-03 16:31:00.706 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] HTTP session returned status 429/Solcast too busy in sites_data()
2024-08-03 16:31:00.706 WARNING (MainThread) [custom_components.solcast_solar.solcastapi] Retries exhausted gathering Solcast sites, last call result: 429/Solcast too busy, using cached data if it exists
2024-08-03 16:31:00.706 ERROR (MainThread) [custom_components.solcast_solar.solcastapi] Cached Solcast sites are not yet available for ******NV8ggJ to cope with API call failure
2024-08-03 16:31:00.706 ERROR (MainThread) [custom_components.solcast_solar.solcastapi] At least one successful API 'get sites' call is needed, so the integration will not function correctly
2024-08-03 16:31:00.706 ERROR (MainThread) [custom_components.solcast_solar.solcastapi] https://api.solcast.com.au HTTP status error 404/Not found in sites_data() while gathering sites
2024-08-03 16:31:00.706 ERROR (MainThread) [custom_components.solcast_solar.solcastapi] Solcast integration did not start correctly, as site(s) are needed. Suggestion: Restart the integration
2024-08-03 16:31:00.707 ERROR (MainThread) [custom_components.solcast_solar.solcastapi] Exception in sites_data(): Traceback (most recent call last):
  File "/config/custom_components/solcast_solar/solcastapi.py", line 266, in sites_data
    raise Exception(f"HTTP sites_data error: Solcast Error gathering sites")
Exception: HTTP sites_data error: Solcast Error gathering sites

2024-08-03 16:31:00.707 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] Getting API limit and usage from solcast for ******NV8ggJ
2024-08-03 16:31:00.707 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] API usage cache exists
2024-08-03 16:31:00.719 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] HTTP session returned status 429/Solcast too busy in sites_usage()
2024-08-03 16:31:00.722 INFO (MainThread) [custom_components.solcast_solar.solcastapi] Loaded API usage cache
2024-08-03 16:31:00.722 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] API counter for ******NV8ggJ is 4/10
2024-08-03 16:31:06.306 INFO (MainThread) [hass_nabucasa.google_report_state] Timeout while waiting to receive message
2024-08-03 16:31:10.800 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] Configuration directory is /config
2024-08-03 16:31:10.800 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] Sites cache does not yet exist
2024-08-03 16:31:10.800 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] Connecting to https://api.solcast.com.au/rooftop_sites?format=json&api_key=******NV8ggJ
2024-08-03 16:31:10.811 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] HTTP session returned status 429/Solcast too busy in sites_data()
2024-08-03 16:31:10.811 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] Will retry get sites, retry 1
2024-08-03 16:31:15.823 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] HTTP session returned status 429/Solcast too busy in sites_data()
2024-08-03 16:31:15.824 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] Will retry get sites, retry 2
2024-08-03 16:31:20.835 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] HTTP session returned status 429/Solcast too busy in sites_data()
2024-08-03 16:31:20.835 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] Will retry get sites, retry 3
2024-08-03 16:31:25.893 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] HTTP session returned status 200/Success in sites_data()
2024-08-03 16:31:25.895 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] Writing sites cache
2024-08-03 16:31:25.897 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] Sites data: {'sites': [{'name': 'Iris North-East', 'resource_id': 'b68d-c05a-c2b3-2cf9', 'capacity': 6.857, 'capacity_dc': 7.92, 'longitude': **.******, 'latitude': **.******, 'azimuth': -67, 'tilt': 26, 'loss_factor': 0.95, 'tags': []}, {'name': 'Iris North-West', 'resource_id': '83d5-ab72-2a9a-2397', 'capacity': 5.243, 'capacity_dc': 5.72, 'longitude': **.******, 'latitude': **.******, 'azimuth': 27, 'tilt': 17, 'loss_factor': 0.95, 'tags': []}], 'page_count': 1, 'current_page': 1, 'total_records': 2}
2024-08-03 16:31:25.897 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] Getting API limit and usage from solcast for ******NV8ggJ
2024-08-03 16:31:25.897 DEBUG (MainThread) [custom_components.solcast_solar.solcastapi] API usage cache exists```