### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ See [detailed](#hacs-recommended) instructions below.  Now that HACS 2.0 has bee
 [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=BJReplay&repository=ha-solcast-solar&category=integration)
 
 > [!WARNING]  
-> This repository is **not** currently in HACS, awaiting [this PR](https://github.com/hacs/default/pull/2535) to be merged. Install using the [HACS *(recommended)*](#hacs-recommended) instructions below: 
+> This repository is **not** currently in HACS, awaiting [this PR](https://github.com/hacs/default/pull/2535) to be merged. Install using the [HACS *(recommended)*](#hacs-recommended) instructions below.
 
 > [!NOTE]
 >
@@ -44,7 +44,7 @@ This custom component integrates the Solcast Hobby PV Forecast API into Home Ass
 > [!NOTE]
 >
 > 
-> Solcast have altered their API limits for new account creators
+> Solcast have altered their API limits for new account creators.
 >
 > Solcast now only offer new account creators a limit of 10 API calls per day (used to be 50). 
 > Old account users still have 50 API calls.


### PR DESCRIPTION
The HACS blockquote rendering is supposedly better given v2.0.1, but still terrible as far as paragraph breaks are concerned @BJReplay, with information frankly unreadble in places. You can get the gist, but you shouldn't have to squint and mentally insert line breaks.

These small changes make one note up the top more readable, adding a missing full stop that I didn't notice.

(Unless you actually get propper paragraphs in blockquotes now and I don't for some reason...)

We should not link the readme at github.com at the start, with a note about the formatting when "reading this in HACS". That would be odd. We should not need to. We should instead raise an issue on HACS about paragraph breaks being missing.

(I wonder whether the extra lines in blockquotes up the top are now not required for 2.0.1... More testing over at autoSteve and a release there required for that. Tomorrow.)