### PR TITLE
Add allow action site parameter with hyphen or underscore

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,7 +614,7 @@ You can change the dampening factor value for any hour. Values from 0.0 - 1.0 ar
 
 Setting dampening for individual Solcast sites or using half-hour intervals is possible. This requires use of either the `solcast_solar.set_dampening` action, or creation/modification of a file in the Home Assistant config folder called `solcast-dampening.json`.
 
-The action accepts a string of dampening factors, and also an optional site resource ID. For hourly dampening supply 24 values. For half-hourly 48. Calling the action creates or updates the file `solcast-dampening.json` when either a site or 48 factor values are specified. If setting overall dampening with 48 factors, then an optional 'all' site may be specified (or simply omitted for this use case).
+The action accepts a string of dampening factors, and also an optional site resource ID. (The optional site may be specified with either hyphens or underscores.) For hourly dampening supply 24 values. For half-hourly 48. Calling the action creates or updates the file `solcast-dampening.json` when either a site or 48 factor values are specified. If setting overall dampening with 48 factors, then an optional 'all' site may be specified (or simply omitted for this use case).
 
 ```yaml
 action: solcast_solar.set_dampening
@@ -674,7 +674,7 @@ Example of half-hourly dampening for all sites:
 
 When calculating dampening using an automation it may be beneficial to use un-dampened forecast values as input.
 
-This is possible by using the action `solcast_solar.query_forecast_data`, and including `undampened: true` in the parameters. The site may also be included in the action parameters if a breakdown is desired.
+This is possible by using the action `solcast_solar.query_forecast_data`, and including `undampened: true` in the parameters. The site may also be included in the action parameters if a breakdown is desired. (The optional site may be specified with either hyphens or underscores.)
 
 ```yaml
 action: solcast_solar.query_forecast_data
@@ -689,7 +689,7 @@ Un-dampened forecast history is retained for just 14 days.
 
 #### Reading dampening values
 
-The currently set dampening factors may be retrieved using the action "Solcast PV Forecast: Get forecasts dampening" (`solcast_solar.get_dampening`). This may specify an optional site resource ID, or specify no site or the site 'all'. Where no site is specified then all sites with dampening set will be returned. An error is raised should a site not have dampening set.
+The currently set dampening factors may be retrieved using the action "Solcast PV Forecast: Get forecasts dampening" (`solcast_solar.get_dampening`). This may specify an optional site resource ID, or specify no site or the site 'all'. (The optional site may be specified with either hyphens or underscores.) Where no site is specified then all sites with dampening set will be returned. An error is raised should a site not have dampening set.
 
 If granular dampening is set to specify both individual site dampening factors and "all" sites dampening factors, then attempting retrieval of an individual site dampening factors will result in the "all" sites dampening factors being returned, with the "all" site being noted in the response. This is because an "all" set of dampening factors overrides the individual site settings in this circumstance.
 
@@ -1009,6 +1009,7 @@ The code itself resides at `/config/custom_components/solcast_solar`, and removi
 
 v4.3.6
 * Add last_attempt attribute to api_last_polled entity by @autoSteve
+* Add allow action site parameter with hyphen or underscore by @autoSteve
 
 Full Changelog: https://github.com/BJReplay/ha-solcast-solar/compare/v4.3.5...v4.3.6
 

--- a/custom_components/solcast_solar/__init__.py
+++ b/custom_components/solcast_solar/__init__.py
@@ -410,7 +410,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:  #
             data = await coordinator.service_query_forecast_data(
                 dt_util.as_utc(call.data.get(EVENT_START_DATETIME, dt_util.now())),
                 dt_util.as_utc(call.data.get(EVENT_END_DATETIME, dt_util.now())),
-                call.data.get(SITE, "all"),
+                call.data.get(SITE, "all").replace("_", "-"),
                 call.data.get(UNDAMPENED, False),
             )
         except ValueError as e:
@@ -441,7 +441,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:  #
         if len(factors) not in (24, 48):
             raise ServiceValidationError(translation_domain=DOMAIN, translation_key="damp_count_not_correct")
         if site is not None:
-            site = site.lower()
+            site = site.lower().replace("_", "-")
             if site == "all":
                 if (len(factors)) != 48:
                     raise ServiceValidationError(translation_domain=DOMAIN, translation_key="damp_no_all_24")
@@ -499,7 +499,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:  #
         """
         _LOGGER.info("Action: Get dampening")
 
-        data = await solcast.get_dampening(call.data.get(SITE))  # Optional site.
+        site = call.data.get(SITE)  # Optional site.
+        if site is not None:
+            site = site.lower().replace("_", "-")
+        data = await solcast.get_dampening(site)
         return {"data": data}
 
     async def action_call_set_hard_limit(call: ServiceCall) -> None:


### PR DESCRIPTION
The Solcast "site" is presented in attributes using underscores, and not hyphens, and this is to accommodate Home Assistant. To allow consistency, service actions should also allow sites specified using underscores.