### PR TITLE
Modify language links in README*.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ![GitHub commit activity](https://img.shields.io/github/commit-activity/y/BJReplay/ha-solcast-solar?style=for-the-badge)
 ![Maintenance](https://img.shields.io/maintenance/yes/2026?style=for-the-badge)
 
-**Languages:** [🇦🇺 English](https://github.com/BJReplay/ha-solcast-solar/blob/main/README.md) | [🇫🇷 Français](https://github.com/BJReplay/ha-solcast-solar/blob/main/README_fr.md) | [🇩🇪 Deutsch](https://github.com/BJReplay/ha-solcast-solar/blob/main/README_de.md)
+**Languages:** [🇦🇺 English](https://github.com/BJReplay/ha-solcast-solar/blob/main/README.md) | [🇩🇪 Deutsch](https://github.com/BJReplay/ha-solcast-solar/blob/main/README_de.md) | [🇫🇷 Français](https://github.com/BJReplay/ha-solcast-solar/blob/main/README_fr.md)
 
 ## Preamble
 

--- a/README_de.md
+++ b/README_de.md
@@ -4,7 +4,7 @@
 
 [](https://github.com/custom-components/hacs)![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg?style=for-the-badge)![GitHub-Veröffentlichung](https://img.shields.io/github/v/release/BJReplay/ha-solcast-solar?style=for-the-badge)[](https://github.com/BJReplay/ha-solcast-solar/releases/latest)![hacs_downloads](https://img.shields.io/github/downloads/BJReplay/ha-solcast-solar/latest/total?style=for-the-badge)![GitHub-Lizenz](https://img.shields.io/github/license/BJReplay/ha-solcast-solar?style=for-the-badge)![GitHub-Commit-Aktivität](https://img.shields.io/github/commit-activity/y/BJReplay/ha-solcast-solar?style=for-the-badge)![Wartung](https://img.shields.io/maintenance/yes/2026?style=for-the-badge)
 
-**Languages:** [🇦🇺 English](https://github.com/BJReplay/ha-solcast-solar/blob/main/README.md) | [🇫🇷 Français](https://github.com/BJReplay/ha-solcast-solar/blob/main/README_fr.md) | [🇩🇪 Deutsch](https://github.com/BJReplay/ha-solcast-solar/blob/main/README_de.md)
+**Languages:** [🇦🇺 English](https://github.com/BJReplay/ha-solcast-solar/blob/main/README.md) | [🇩🇪 Deutsch](https://github.com/BJReplay/ha-solcast-solar/blob/main/README_de.md) | [🇫🇷 Français](https://github.com/BJReplay/ha-solcast-solar/blob/main/README_fr.md)
 
 ## Präambel
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -4,7 +4,7 @@
 
 [](https://github.com/custom-components/hacs)![badge hacs](https://img.shields.io/badge/HACS-Default-orange.svg?style=for-the-badge)![Publication GitHub](https://img.shields.io/github/v/release/BJReplay/ha-solcast-solar?style=for-the-badge)[](https://github.com/BJReplay/ha-solcast-solar/releases/latest)![téléchargements hacs](https://img.shields.io/github/downloads/BJReplay/ha-solcast-solar/latest/total?style=for-the-badge)![Licence GitHub](https://img.shields.io/github/license/BJReplay/ha-solcast-solar?style=for-the-badge)![Activité de commit sur GitHub](https://img.shields.io/github/commit-activity/y/BJReplay/ha-solcast-solar?style=for-the-badge)![Entretien](https://img.shields.io/maintenance/yes/2026?style=for-the-badge)
 
-**Languages:** [🇦🇺 English](https://github.com/BJReplay/ha-solcast-solar/blob/main/README.md) | [🇫🇷 Français](https://github.com/BJReplay/ha-solcast-solar/blob/main/README_fr.md) | [🇩🇪 Deutsch](https://github.com/BJReplay/ha-solcast-solar/blob/main/README_de.md)
+**Languages:** [🇦🇺 English](https://github.com/BJReplay/ha-solcast-solar/blob/main/README.md) | [🇩🇪 Deutsch](https://github.com/BJReplay/ha-solcast-solar/blob/main/README_de.md) | [🇫🇷 Français](https://github.com/BJReplay/ha-solcast-solar/blob/main/README_fr.md)
 
 ## Préambule
 


### PR DESCRIPTION
I am fairly certain that the relative links to translated readme files will not work from HACS, because that scrapes a version of the readme as-at the released version. There is no documentation to indicate whether README*.md files are scraped.

This makes those links absolute to GitHub and not relative.