### PR TITLE
fix: make config file migration asynchronous to prevent blocking I/O …

### DIFF
--- a/custom_components/solcast_solar/__init__.py
+++ b/custom_components/solcast_solar/__init__.py
@@ -403,6 +403,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:  #
 
     hass.data[DOMAIN][PRESUMED_DEAD] = True  # Presumption that init will not be successful.
     solcast = SolcastApi(aiohttp_client.async_get_clientsession(hass), options, hass, entry)
+    await solcast.async_migrate_config_files()
     await solcast.read_advanced_options()
 
     solcast.headers = get_session_headers(solcast, version)


### PR DESCRIPTION
## Description

This PR resolves a blocking I/O issue detected in the event loop during the integration startup.

The `migrate_config_files` method was performing file system operations (`glob`, `scandir`, `unlink`) synchronously within the main event loop. This caused `BlockingIOError` or warnings about blocking calls, particularly noticeable in environments running newer Python versions (3.14) or stricter Home Assistant configurations.

## Changes

- Refactored `SolcastApi.migrate_config_files` into:
  - `_migrate_config_files`: A synchronous method that handles the file system logic and returns a list of removed files.
  - `async_migrate_config_files`: An async wrapper that offloads the synchronous method to the executor using `hass.async_add_executor_job`.
- Updated `__init__.py` to await `solcast.async_migrate_config_files()` during `async_setup_entry`.

Fixes #455
